### PR TITLE
Fix exception when `scout_apm` isn't required separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+# 1.0.1
+
+* Fix when `scout_apm` isn't installed separately
+
+# 1.0.0
+
+🚀

--- a/lib/server_timing.rb
+++ b/lib/server_timing.rb
@@ -4,6 +4,8 @@ module ServerTiming
   end
 end
 
+require "scout_apm"
+
 require "server_timing/auth"
 require "server_timing/middleware"
 require "server_timing/railtie" if ServerTiming.rails?

--- a/lib/server_timing/version.rb
+++ b/lib/server_timing/version.rb
@@ -1,3 +1,3 @@
 module ServerTiming
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
See #1.

`scout_apm` wasn't required in the `server_timing` gem, just included as a dependency.