### PR TITLE
switch single-quote to double-quote

### DIFF
--- a/lib/server_timing/timing_metric.rb
+++ b/lib/server_timing/timing_metric.rb
@@ -23,7 +23,7 @@ module ServerTiming
 
     def description_to_header
       return unless description
-      "desc='#{description}';"
+      "desc=\"#{description}\";"
     end
   end
 end


### PR DESCRIPTION
Per [spec](https://tools.ietf.org/html/rfc7230#section-3.2.6), `quoted-string`s need to be wrapped in `DQUOTE`s.

Also, note that I don't know ruby, so I didn't run this code, but i figure escaping is escaping. :)